### PR TITLE
Tone down the checks where appropriate

### DIFF
--- a/pentaho_checkStyle.xml
+++ b/pentaho_checkStyle.xml
@@ -194,7 +194,6 @@
 
         <!-- Checks for class design                         -->
         <!-- See http://checkstyle.sf.net/config_design.html -->
-        <module name="FinalClass"/>
         <module name="HideUtilityClassConstructor"/>
         <module name="InterfaceIsType"/>
         <module name="ThrowsCount">


### PR DESCRIPTION
Removes "Return count" check, as the discussion ended in "lets kill it"

Ignore magic numbers for HashCode. A good hashcode function will always have a prime number to spread out the bits. 

```
public int hashCode()
{
  int result = locale != null ? locale.hashCode() : 0;
  result = 31 * result + (timeZone != null ? timeZone.hashCode() : 0);
  return result;
}
```

And dont flag final checks for classes. It does not add anything to good coding style. A class that has only private constructors cannot be subclasssed anyway, and thus the final modifier is redundant. 
However, that stupid check flags private inner classes, which are not even part of the public interface and thus it cannot even claim to do any good here. Just kill it!
