### PR TITLE
Lets value readability over terseness. 

### DIFF
--- a/pentaho_checkStyle.xml
+++ b/pentaho_checkStyle.xml
@@ -175,8 +175,6 @@
         </module>
         <module name="MissingSwitchDefault"/>
         <module name="RedundantThrows"/>
-        <module name="SimplifyBooleanExpression"/>
-        <module name="SimplifyBooleanReturn"/>
         <module name="IllegalThrows"/>
         <module name="DeclarationOrder"/>
         <module name="ParameterAssignment"/>


### PR DESCRIPTION
If no one cares religiously
whether there is an extra false added, then removing that check
will make both sides happy. Those who write terse statements can
do so, and those who need extra clarity can do so as well.

If in doubt, give it to discussion. It will be a quick silence, I am dead sure of it.
