### PR TITLE
Add configuration for throws clause indentation

### DIFF
--- a/pentaho_checkStyle.xml
+++ b/pentaho_checkStyle.xml
@@ -198,10 +198,7 @@
         <module name="Indentation">
             <property name="basicOffset" value="2"/>
             <property name="caseIndent" value="2"/>
+            <property name="throwsIndent" value="2"/>
         </module>
-
-
-
     </module>
-
 </module>

--- a/pentaho_checkStyle_future_goal.xml
+++ b/pentaho_checkStyle_future_goal.xml
@@ -137,12 +137,11 @@
         <module name="NoWhitespaceBefore"/>
         <module name="OperatorWrap"/>
         <!-- <module name="ParenPad"/> -->
-            
+
         <module name="ParenPad">
             <property name="tokens" value="RPAREN, LPAREN"/>
             <property name="option" value="space"/>
         </module>
-                
 
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter"/>
@@ -219,10 +218,7 @@
         <module name="Indentation">
             <property name="basicOffset" value="2"/>
             <property name="caseIndent" value="2"/>
+            <property name="throwsIndent" value="2"/>
         </module>
-
-
-
     </module>
-
 </module>


### PR DESCRIPTION
Checkstyle reports hundreds of errors for code like this (while being run from ant via CLI):
public void someMethodWithLongSignatureSoThrowsMovesToNextLine()
  throws SomeException

The earliest report about that is date 2008: http://en.it-usenet.org/thread/13413/346

https://github.com/checkstyle/checkstyle/pull/80 adds throwsIndent configuration parameter and finally resolves the issue.

See checkstyle's doc for more details http://checkstyle.sourceforge.net/config_misc.html#Indentation
