### PR TITLE
[CLEANUP] - JavaScript formatting rules

### DIFF
--- a/codeStyleSettings.xml
+++ b/codeStyleSettings.xml
@@ -20,6 +20,10 @@
         <option name="HTML_TEXT_WRAP" value="0" />
         <option name="HTML_ALIGN_ATTRIBUTES" value="false" />
         <option name="WRAP_COMMENTS" value="true" />
+        <JSCodeStyleSettings>
+          <option name="ALIGN_OBJECT_PROPERTIES" value="1" />
+          <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+        </JSCodeStyleSettings>
         <XML>
           <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
@@ -98,6 +102,30 @@
           </indentOptions>
         </codeStyleSettings>
         <codeStyleSettings language="JavaScript">
+          <option name="RIGHT_MARGIN" value="110" />
+          <option name="KEEP_LINE_BREAKS" value="false" />
+          <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+          <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+          <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+          <option name="ALIGN_MULTILINE_FOR" value="false" />
+          <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+          <option name="SPACE_BEFORE_IF_PARENTHESES" value="false" />
+          <option name="SPACE_BEFORE_WHILE_PARENTHESES" value="false" />
+          <option name="SPACE_BEFORE_FOR_PARENTHESES" value="false" />
+          <option name="SPACE_BEFORE_CATCH_PARENTHESES" value="false" />
+          <option name="SPACE_BEFORE_SWITCH_PARENTHESES" value="false" />
+          <option name="CALL_PARAMETERS_WRAP" value="1" />
+          <option name="METHOD_PARAMETERS_WRAP" value="1" />
+          <option name="BINARY_OPERATION_WRAP" value="1" />
+          <option name="TERNARY_OPERATION_WRAP" value="1" />
+          <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+          <option name="KEEP_SIMPLE_BLOCKS_IN_ONE_LINE" value="true" />
+          <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+          <option name="ARRAY_INITIALIZER_WRAP" value="5" />
+          <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
+          <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+          <option name="ASSIGNMENT_WRAP" value="5" />
+          <option name="WRAP_COMMENTS" value="true" />
           <indentOptions>
             <option name="INDENT_SIZE" value="2" />
             <option name="TAB_SIZE" value="2" />
@@ -133,4 +161,3 @@
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
   </component>
 </project>
-


### PR DESCRIPTION
This is a "sub-optimal" configuration, restricted by what CheckStyle provides (or to what I know about it...).

For example, I personally like aligning `=` signs or values in object literals' properties. However, I do it only to a certain extent. If the lengths of the variable or property names are very disparate, it gets ugly, so I end up aligning these in alignment groups... The provided options are all or nothing, and so I have to choose nothing :-(

The same could be said for arguments alignment, for "identical" function calls made in consecutive lines... How could this be automated?

The way argument lists are aligned when they don't fit, and which sub-expression is chosen to start spreading vertically or wrapping... is also something I'm not especially happy with.

Another problem is the "respect line breaks option". We want it on so that there is a way to force certain formattings, not supported by the rules. We want it off, temporarily, to force formatting of a completely messed up file...

One very controversial aspect of the configuration I am proposing is not forcing the use of braces in statements having a single body line. Here's *my argument* in defense of this style:

* I've fallen in the trap sometimes myself (and @pamval can prove this to you!). Note, however, that the trap exists more due to the incorrect indentation and spacing, rather than to the missing braces. Indentation — that is key, and (should be) enforced by the rules.
* I do feel legibility suffers a lot with the mandatory braces rule — everything gets unnecessarily inflated. Conciseness suffers as well.
* Many "world class" JavaScript programmers consciously choose this path as well.
* Any programmer should use braces whenever:
  * the resulting code would in any way become hard to read
  * a contained statement uses braces (no confusion between inner/outer braces)
  * an alternate branch uses braces (no unbalanced if/else use of braces)
* Any programmer should use indentation and/or an empty line to make the code readable (like adding an empty line after an `if` that does not uses braces)
* Leads to better looking, cleaner code (a lower concentration of black over white)
* It's not hard to add the braces if you later need to add additional child statements, and the gained readability surely compensates for this annoyance
* Not Java — JavaScript is much more about _inline_ code.
* I see the rule as a form of prejudice and fear

I'm obviously open to losing the battle against the "parens police culture" ;-)

@CodeOnCoffee please comment and experiment with.