### PR TITLE
[CLEANUP] Modified coding style to mach check style...

### DIFF
--- a/codeStyleSettings.xml
+++ b/codeStyleSettings.xml
@@ -52,8 +52,8 @@
           <option name="SPACE_WITHIN_BRACKETS" value="true" />
           <option name="SPACE_WITHIN_BRACES" value="true" />
           <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
-          <option name="SPACE_BEFORE_SWITCH_PARENTHESES" value="false" />
-          <option name="SPACE_BEFORE_SYNCHRONIZED_PARENTHESES" value="false" />
+          <option name="SPACE_BEFORE_SWITCH_PARENTHESES" value="true" />
+          <option name="SPACE_BEFORE_SYNCHRONIZED_PARENTHESES" value="true" />
           <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
           <option name="SPACE_BEFORE_ANNOTATION_ARRAY_INITIALIZER_LBRACE" value="true" />
           <option name="CALL_PARAMETERS_WRAP" value="1" />


### PR DESCRIPTION
There was a mismtach in regards to spaces before 'switch' and 'sycnhronized'  paranthesis.
This fixes warnings we get in this regard when running the check style tool in the idea for this.