### PR TITLE
Changed the Prettier configuration to have bracket spacing.

### DIFF
--- a/packages/prettier-config/index.js
+++ b/packages/prettier-config/index.js
@@ -7,7 +7,7 @@ module.exports = {
   "quoteProps": "as-needed",
   "jsxSingleQuote": false,
   "trailingComma": "none",
-  "bracketSpacing": false, // not default
+  "bracketSpacing": true,
   "jsxBracketSameLine": true, // not default
   "arrowParens": "avoid",
   "requirePragma": false,

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hitachivantara/prettier-config",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Hitachi Vantara Default Prettier Configuration",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
I was going to apply the prettier coding standards to our new project, but when I did the code started looking a bit hard to read when importing the needed modules for each component.

How it looks using the current prettier settings from _pentaho-coding-standards_ repository:
```
import React, {useEffect} from "react";
import {RouterState} from "connected-react-router";
import {useTranslation} from "react-i18next";
import HvHeader from "@hv/uikit-react-core/dist/Header";
import HvUserIcon from "@hv/uikit-react-icons/dist/Generic/User";
import HitachiLogo from "assets/hitachi-logo.svg";
import {View} from "models/views";
import {HeaderProps} from "./index";
```

How it will look with the proposed change:
```
import React, { useEffect } from "react";
import { RouterState } from "connected-react-router";
import { useTranslation } from "react-i18next";
import HvHeader from "@hv/uikit-react-core/dist/Header";
import HvUserIcon from "@hv/uikit-react-icons/dist/Generic/User";
import HitachiLogo from "assets/hitachi-logo.svg";
import { View } from "models/views";
import { HeaderProps } from "./index";
```

I believe that this is much easier to read than the first example.

Let me know what you guys think.