### PR TITLE
[CLEANUP] Adding checks for multi-line new lines

### DIFF
--- a/checkstyle/pentaho_checks.xml
+++ b/checkstyle/pentaho_checks.xml
@@ -151,5 +151,12 @@
       <property name="allowEmptyLoops" value="false"/>
       <property name="allowEmptyTypes" value="false"/>
     </module>
+    <module name="EmptyLineSeparator">
+      <property name="severity" value="info"/>
+      <property name="tokens" value="VARIABLE_DEF, METHOD_DEF, CTOR_DEF, ENUM_DEF"/>
+      <property name="allowNoEmptyLineBetweenFields" value="true"/>
+      <property name="allowMultipleEmptyLines" value="false"/>
+      <property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+    </module>
   </module>
 </module>


### PR DESCRIPTION
This fix will capture multi-line new lines in checkstyle between and inside class members, methods, constructors and enums.
Reference: https://checkstyle.sourceforge.io/config_whitespace.html#EmptyLineSeparator