### PR TITLE
Changed the Prettier configuration bracket different line

### DIFF
--- a/packages/prettier-config/index.js
+++ b/packages/prettier-config/index.js
@@ -8,7 +8,6 @@ module.exports = {
   "jsxSingleQuote": false,
   "trailingComma": "none",
   "bracketSpacing": true,
-  "jsxBracketSameLine": true, // not default
   "arrowParens": "avoid",
   "requirePragma": false,
   "insertPragma": false,


### PR DESCRIPTION
Change jsxBracketSameLine to the default false. In terms of readability when using react with a component with several properies:
With true:
```
<button
  className="prettier-class"
  id="prettier-id"
  onClick={this.handleClick}>
  Click Here
</button>
```
With false:
```
<button
  className="prettier-class"
  id="prettier-id"
  onClick={this.handleClick}
>
  Click Here
</button>
```

the latest is easier to read