### PR TITLE
[DEVO-14362] Repoint Maven repository URLs to repo.pentaho.com

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,10 @@
   </distributionManagement>
 
   <properties>
-    <pentaho.public.release.repo>https://repo.orl.eng.hitachivantara.com/artifactory/pntpub-mvn-dev-orl/</pentaho.public.release.repo>
-    <pentaho.public.snapshot.repo>https://repo.orl.eng.hitachivantara.com/artifactory/pntpub-mvn-snapshot-orl/</pentaho.public.snapshot.repo>
-    <pentaho.private.release.repo>https://repo.orl.eng.hitachivantara.com/artifactory/pntprv-mvn-dev-orl/</pentaho.private.release.repo>
-    <pentaho.private.snapshot.repo>https://repo.orl.eng.hitachivantara.com/artifactory/pntprv-mvn-snapshot-orl/</pentaho.private.snapshot.repo>
+    <pentaho.public.release.repo>https://repo.pentaho.com/artifactory/pntpub-mvn-dev-orl/</pentaho.public.release.repo>
+    <pentaho.public.snapshot.repo>https://repo.pentaho.com/artifactory/pntpub-mvn-snapshot-orl/</pentaho.public.snapshot.repo>
+    <pentaho.private.release.repo>https://repo.pentaho.com/artifactory/pntprv-mvn-dev-orl/</pentaho.private.release.repo>
+    <pentaho.private.snapshot.repo>https://repo.pentaho.com/artifactory/pntprv-mvn-snapshot-orl/</pentaho.private.snapshot.repo>
 
     <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
     <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
@@ -130,7 +130,7 @@
     <repository>
       <id>pentaho-public</id>
       <name>Pentaho Public</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <releases>
         <enabled>true</enabled>
         <updatePolicy>daily</updatePolicy>
@@ -146,7 +146,7 @@
     <pluginRepository>
       <id>pentaho-public-plugins</id>
       <name>Pentaho Public Plugins</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>


### PR DESCRIPTION
### DEVO-14362 — repoint Maven repository URLs to `repo.pentaho.com`

Replaces the retiring host `repo.orl.eng.hitachivantara.com` with
`repo.pentaho.com`.

**Change:** 1 POM file(s), 6 occurrence(s). Private (`pntprv-*`) paths present: yes.

**Host-only substitution.** Scheme, the `/artifactory/<path>/` segment and any
trailing slash are byte-identical; repository `<id>` and `<name>` are
untouched. Verified with `git diff --check` and a hostname-normalised
before/after diff that comes back empty, so nothing but the hostname moved.

**Files changed:**
  - `pom.xml`

**Not changed (out of scope for this ticket — non-POM files), reported for follow-up:**
  - `packages/prettier-config/package.json`

**Verification:** `mvn -q validate` passes.

---

This is part of a **coordinated change across 87 repositories in two orgs**
(`pentaho` and `webdetails`), tracked under DEVO-14362.

The full PR index — one row per repository, including those deliberately
skipped — is maintained at:
https://github.com/cardosov/devops-tasks/blob/task/devo-14362/.agent/memory/pull-requests.md

Please do not merge until the batch is reviewed as a whole.
