### PR TITLE
DEVO-14362: point Maven repository URLs at repo.pentaho.com (10.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,10 @@
   </distributionManagement>
 
   <properties>
-    <pentaho.public.release.repo>https://repo.orl.eng.hitachivantara.com/artifactory/pntpub-mvn-dev-orl/</pentaho.public.release.repo>
-    <pentaho.public.snapshot.repo>https://repo.orl.eng.hitachivantara.com/artifactory/pntpub-mvn-snapshot-orl/</pentaho.public.snapshot.repo>
-    <pentaho.private.release.repo>https://repo.orl.eng.hitachivantara.com/artifactory/pntprv-mvn-dev-orl/</pentaho.private.release.repo>
-    <pentaho.private.snapshot.repo>https://repo.orl.eng.hitachivantara.com/artifactory/pntprv-mvn-snapshot-orl/</pentaho.private.snapshot.repo>
+    <pentaho.public.release.repo>https://repo.pentaho.com/artifactory/pntpub-mvn-dev-orl/</pentaho.public.release.repo>
+    <pentaho.public.snapshot.repo>https://repo.pentaho.com/artifactory/pntpub-mvn-snapshot-orl/</pentaho.public.snapshot.repo>
+    <pentaho.private.release.repo>https://repo.pentaho.com/artifactory/pntprv-mvn-dev-orl/</pentaho.private.release.repo>
+    <pentaho.private.snapshot.repo>https://repo.pentaho.com/artifactory/pntprv-mvn-snapshot-orl/</pentaho.private.snapshot.repo>
 
     <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
     <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
@@ -130,7 +130,7 @@
     <repository>
       <id>pentaho-public</id>
       <name>Pentaho Public</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <releases>
         <enabled>true</enabled>
         <updatePolicy>daily</updatePolicy>
@@ -146,7 +146,7 @@
     <pluginRepository>
       <id>pentaho-public-plugins</id>
       <name>Pentaho Public Plugins</name>
-      <url>https://repo.orl.eng.hitachivantara.com/artifactory/pnt-mvn/</url>
+      <url>https://repo.pentaho.com/artifactory/pnt-mvn/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>


### PR DESCRIPTION
Backports the DEVO-14362 hostname change to the `10.2` service pack line.

`repo.orl.eng.hitachivantara.com` -> `repo.pentaho.com`, hostname only. Every `/artifactory/<path>/` segment,
scheme and trailing slash is preserved verbatim; no ids, names, versions or
formatting were touched.

- Files changed: 1
- Occurrences replaced: 6
- `mvn validate` passes
- `grep` for the old hostname over all `pom.xml` returns no hits

Base is `10.2`, not the default branch. Ticket: DEVO-14362